### PR TITLE
Adding IntelliJ and Eclipse hidden files to project's .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ out/*
 .settings/
 .project
 .classpath
+
+# Intellij
+.idea/
+*.iml
+*.iws


### PR DESCRIPTION
These have been generated by IntelliJ 13.1 and Eclipse Juno.
